### PR TITLE
Enh/build specific cflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ project(IRTK)
 
 cmake_minimum_required(VERSION 2.8)
 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+               STRINGS "None" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 option(BUILD_APPLICATIONS "Build applications." ON)
 option(BUILD_DOCUMENTATION "Build documentation." OFF)
 #option(BUILD_PACKAGES "Build packages." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ include(IRTKBuildDeps)
 include(IRTKInstallDirs)
 include(IRTKVersion)
 
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  add_definitions(-DNO_BOUNDS)
+endif()
+
 include(TestBigEndian)
 test_big_endian(SYSTEM_IS_BIG_ENDIAN)
 if(SYSTEM_IS_BIG_ENDIAN)


### PR DESCRIPTION
This PR adds conventional handling of different build types and defines the relevant cflags (only NO_BOUNDS actually, IMPERIAL and ANSI aren't used anymore).
