### PR TITLE
Order of include_directories in CMake files

### DIFF
--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -30,7 +30,7 @@ install(FILES ${IRTK_MODULE_HEADERS}
         DESTINATION "${IRTK_MODULE_INSTALL_INCLUDEDIR}"
         COMPONENT dev)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include"
+include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include"
                     "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 add_subdirectory(src)

--- a/Modules/Geometry/CMakeLists.txt
+++ b/Modules/Geometry/CMakeLists.txt
@@ -24,6 +24,6 @@ install(FILES ${IRTK_MODULE_HEADERS}
         DESTINATION "${IRTK_MODULE_INSTALL_INCLUDEDIR}"
         COMPONENT dev)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory(src)

--- a/Modules/Geometry/src/CMakeLists.txt
+++ b/Modules/Geometry/src/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 set(IRTK_MODULE_OUTPUT_NAME "irtk${IRTK_MODULE_NAME}")
 
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Common/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Image/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Common/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Image/include")
 
 set(IRTK_MODULE_SOURCES irtkArith.cc
                         irtkComplexFunction.cc

--- a/Modules/Image/CMakeLists.txt
+++ b/Modules/Image/CMakeLists.txt
@@ -26,6 +26,6 @@ install(FILES ${IRTK_MODULE_HEADERS}
         DESTINATION "${IRTK_MODULE_INSTALL_INCLUDEDIR}"
         COMPONENT dev)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory(src)

--- a/Modules/Image/src/CMakeLists.txt
+++ b/Modules/Image/src/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 set(IRTK_MODULE_OUTPUT_NAME "irtk${IRTK_MODULE_NAME}")
 
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Common/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Common/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
 
 set(IRTK_MODULE_SOURCES irtkAnisoDiffusion.cc
                         irtkBaseImage.cc

--- a/Modules/PolyData/CMakeLists.txt
+++ b/Modules/PolyData/CMakeLists.txt
@@ -24,6 +24,6 @@ install(FILES ${IRTK_MODULE_HEADERS}
         DESTINATION "${IRTK_MODULE_INSTALL_INCLUDEDIR}"
         COMPONENT dev)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory(src)

--- a/Modules/PolyData/src/CMakeLists.txt
+++ b/Modules/PolyData/src/CMakeLists.txt
@@ -16,10 +16,10 @@
 
 set(IRTK_MODULE_OUTPUT_NAME "irtk${IRTK_MODULE_NAME}")
 
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Common/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Image/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Transformation/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Common/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Image/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Transformation/include")
 
 set(IRTK_MODULE_SOURCES
   irtkAsConformalAsPossibleVolumeParameterizer.cc

--- a/Modules/Registration/CMakeLists.txt
+++ b/Modules/Registration/CMakeLists.txt
@@ -24,6 +24,6 @@ install(FILES ${IRTK_MODULE_HEADERS}
         DESTINATION "${IRTK_MODULE_INSTALL_INCLUDEDIR}"
         COMPONENT dev)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory(src)

--- a/Modules/Registration/src/CMakeLists.txt
+++ b/Modules/Registration/src/CMakeLists.txt
@@ -17,10 +17,10 @@
 set(IRTK_MODULE_NAME "Registration")
 set(IRTK_MODULE_OUTPUT_NAME "irtk${IRTK_MODULE_NAME}")
 
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Common/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Image/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Transformation/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Common/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Image/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Transformation/include")
 
 set(IRTK_MODULE_SOURCES irtkAdaptiveLineSearch.cc
                         irtkConjugateGradientDescent.cc
@@ -104,7 +104,7 @@ endif()
 add_library(${IRTK_MODULE_NAME} ${IRTK_MODULE_SOURCES})
 
 if(WITH_VTK)
-  include_directories("${CMAKE_SOURCE_DIR}/Modules/PolyData/include")
+  include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/PolyData/include")
   target_link_libraries(${IRTK_MODULE_NAME} PolyData ${VTK_LIBRARIES})
 endif()
 

--- a/Modules/Transformation/CMakeLists.txt
+++ b/Modules/Transformation/CMakeLists.txt
@@ -24,6 +24,6 @@ install(FILES ${IRTK_MODULE_HEADERS}
         DESTINATION "${IRTK_MODULE_INSTALL_INCLUDEDIR}"
         COMPONENT dev)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory(src)

--- a/Modules/Transformation/src/CMakeLists.txt
+++ b/Modules/Transformation/src/CMakeLists.txt
@@ -16,10 +16,10 @@
 
 set(IRTK_MODULE_OUTPUT_NAME "irtk${IRTK_MODULE_NAME}")
 
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Common/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Image/include")
-include_directories("${CMAKE_SOURCE_DIR}/Modules/Registration/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Common/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Geometry/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Image/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/Modules/Registration/include")
 
 set(IRTK_MODULE_SOURCES irtkAffineTransformation.cc
                         irtkBSplineFreeFormTransformation3D.cc


### PR DESCRIPTION
The order in which include_directories appear in CMake files matters as we do not want previously installed versions of IRTK to interfere with the current build.

The proposed fix was obtained with the following perl one-liner:

```
perl -pi -e 's/include_directories\(\"/include_directories\(BEFORE \"/g'  `find Modules -name CMakeLists.txt`
```

This issue occured while compiling in an Anaconda environment and is highlighted below:

```
In file included from ~/anaconda/conda-bld/work/Modules/Common/include/irtkMath.h:21:
~/anaconda/include/cutil_math.h:26:10: fatal error: 'cuda_runtime.h' file not found
#include <cuda_runtime.h>
         ^
1 error generated.
```

Note that the old `~/anaconda/include/cutil_math.h` is picked up instead of the development version at `~/anaconda/conda-bld/work/Modules/Common/include/cutil_math.h`
